### PR TITLE
ENH remove outdated MPI pinning expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,3 @@ Feedstock Maintainers
 
 * [@awvwgk](https://github.com/awvwgk/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/README.md
+++ b/README.md
@@ -232,3 +232,6 @@ Feedstock Maintainers
 
 * [@awvwgk](https://github.com/awvwgk/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,3 @@ mpi:
   - nompi
   - mpich
   - openmpi
-pin_run_as_build:
-  mpich: x.x
-  openmpi: x.x 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "elpa" %}
 {% set version = "2021.11.001" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set mpi = mpi or "nompi" %}
 
 # ELPA uses suffixes to allow parallel installation of several versions in the same prefix


### PR DESCRIPTION
This feedstock is using outdated MPI pinning expressions. I am updating them to conform to the latest conda-forge standard. 

xref: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/issues/209
Fixes #11